### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,9 @@ def train_model():
         # Save uploaded files and prepare data
         file_paths = []
         for i, file in enumerate(audio_files):
-            save_path = os.path.join(UPLOAD_FOLDER, file.filename)
+            save_path = os.path.normpath(os.path.join(UPLOAD_FOLDER, file.filename))
+            if not save_path.startswith(os.path.abspath(UPLOAD_FOLDER)):
+                raise Exception("Invalid file path")
             file.save(save_path)
             file_paths.append((save_path, labels[i]))
 
@@ -34,7 +36,9 @@ def train_model():
 def process_command():
     try:
         audio = request.files['audio']
-        save_path = os.path.join(UPLOAD_FOLDER, audio.filename)
+        save_path = os.path.normpath(os.path.join(UPLOAD_FOLDER, audio.filename))
+        if not save_path.startswith(os.path.abspath(UPLOAD_FOLDER)):
+            raise Exception("Invalid file path")
         audio.save(save_path)
 
         # Perform inference


### PR DESCRIPTION
Potential fix for [https://github.com/kaveeshbhashitha/vcc/security/code-scanning/4](https://github.com/kaveeshbhashitha/vcc/security/code-scanning/4)

To fix the problem, we need to ensure that the constructed file path is contained within the `UPLOAD_FOLDER`. This can be achieved by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the `UPLOAD_FOLDER`. This approach will prevent directory traversal attacks by ensuring that the final path is within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
