### PR TITLE
Potential fix for code scanning alert no. 3: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,4 +49,5 @@ def process_command():
         return jsonify({'error': str(e)}), 500
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/kaveeshbhashitha/vcc/security/code-scanning/3](https://github.com/kaveeshbhashitha/vcc/security/code-scanning/3)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, we can enable debug mode during development and disable it in production without changing the code.

1. Modify the `app.run(debug=True)` line to use an environment variable to determine whether to run in debug mode.
2. Update the code to read the environment variable and set the debug mode accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
