### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,9 @@ from flask import Flask, render_template, request, jsonify
 import os
 import model
 from utils import extract_features
+import logging
+
+logging.basicConfig(level=logging.ERROR)
 
 app = Flask(__name__)
 UPLOAD_FOLDER = 'uploads'
@@ -30,7 +33,8 @@ def train_model():
         model.train_model(file_paths)
         return jsonify({'message': 'Model trained successfully!'})
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        logging.error("Exception occurred", exc_info=True)
+        return jsonify({'error': 'An internal error has occurred!'}), 500
 
 @app.route('/process-command', methods=['POST'])
 def process_command():
@@ -46,7 +50,8 @@ def process_command():
         result = model.execute_command(predicted_command)
         return jsonify({'result': result})
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        logging.error("Exception occurred", exc_info=True)
+        return jsonify({'error': 'An internal error has occurred!'}), 500
 
 if __name__ == '__main__':
     debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']


### PR DESCRIPTION
Potential fix for [https://github.com/kaveeshbhashitha/vcc/security/code-scanning/1](https://github.com/kaveeshbhashitha/vcc/security/code-scanning/1)

To fix the problem, we need to ensure that detailed error information is logged on the server side, and a generic error message is returned to the user. This can be achieved by using Python's logging module to log the exception details and returning a generic error message in the response.

1. Import the logging module.
2. Configure the logging settings if not already configured.
3. Replace the current exception handling code to log the exception details and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
